### PR TITLE
Update image_processing.py

### DIFF
--- a/custom_components/codeproject_ai_object/image_processing.py
+++ b/custom_components/codeproject_ai_object/image_processing.py
@@ -344,7 +344,7 @@ class ObjectClassifyEntity(ImageProcessingEntity):
         # resize image if different then default
         if self._scale != DEAULT_SCALE:
             newsize = (self._image_width * self._scale, self._image_width * self._scale)
-            self._image.thumbnail(newsize, Image.ANTIALIAS)
+            self._image.thumbnail(newsize, Image.LANCZOS)
             self._image_width, self._image_height = self._image.size
             with io.BytesIO() as output:
                 self._image.save(output, format="JPEG")


### PR DESCRIPTION
ANTIALIAS was removed in Pillow 10.0.0 (after being deprecated through many previous versions). Now you need to use PIL.Image.LANCZOS or PIL.Image.Resampling.LANCZOS.

https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias