### PR TITLE
Update image_processing.py

### DIFF
--- a/custom_components/codeproject_ai_object/image_processing.py
+++ b/custom_components/codeproject_ai_object/image_processing.py
@@ -344,7 +344,7 @@ class ObjectClassifyEntity(ImageProcessingEntity):
         # resize image if different then default
         if self._scale != DEAULT_SCALE:
             newsize = (self._image_width * self._scale, self._image_width * self._scale)
-            self._image.thumbnail(newsize, Image.ANTIALIAS)
+            self._image.thumbnail(newsize, Image.Resampling.LANCZOS)
             self._image_width, self._image_height = self._image.size
             with io.BytesIO() as output:
                 self._image.save(output, format="JPEG")


### PR DESCRIPTION
Fix AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS' Image.ANTIALIAS was deprecated and finally removed in Pillow 10.